### PR TITLE
add TitleCase to enum names to support iOS enum conventions

### DIFF
--- a/lib/descriptors/EnumDescriptor.js
+++ b/lib/descriptors/EnumDescriptor.js
@@ -5,6 +5,7 @@
 
 var util = require('util')
 var Descriptor = require('./Descriptor')
+var helper = require('../helper')
 
 /**
  * @param {string} name Name of the enumeration
@@ -63,7 +64,11 @@ EnumDescriptor.prototype.getNames = function () {
 
 EnumDescriptor.prototype.getValueForNumber = function (number) {
   var name = this._names[number]
-  return name ? { name: name, number: number } : null
+  return name ? {
+    name: name,
+    titleName: helper.toTitleCase(name),
+    number: number
+  } : null
 }
 
 

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -57,7 +57,8 @@ exports.extend = function (var_args) {
  * @return {string}
  */
 exports.toCamelCase = function(str) {
-  return String(str).replace(/\_([a-z])/g, function(all, match) {
+  var lowerCase = str.toLowerCase()
+  return String(lowerCase).replace(/\_([a-z])/g, function(all, match) {
     return match.toUpperCase()
   })
 }

--- a/tests/project_test.js
+++ b/tests/project_test.js
@@ -30,9 +30,10 @@ exports.testGetProtos = function (test) {
   var enums = personProtos[0].toTemplateObject().messages[0].enums
   test.equal(1, enums && enums.length)
   test.deepEqual(
-    {name: 'PhoneType', values: [{name: 'MOBILE', number: 0},
-                                 {name: 'HOME', number: 1},
-                                 {name: 'WORK', number: 2}]},
+    {name: 'PhoneType', values: [{name: 'MOBILE', titleName: 'Mobile', number: 0},
+                                 {name: 'HOME', titleName: 'Home', number: 1},
+                                 {name: 'WORK', titleName: 'Work', number: 2},
+                                 {name: 'WORK_FAX', titleName: 'WorkFax', number: 3}]},
     enums[0])
 
   test.done()

--- a/tests/protos/person.proto
+++ b/tests/protos/person.proto
@@ -21,6 +21,7 @@ message Person {
     // Comment
     HOME = 1;
     WORK = 2;
+    WORK_FAX = 3;
   }
 
   message PhoneNumber {


### PR DESCRIPTION
Hello @nicks, @jyhsu, 

Please review the following commits I made in branch 'giannic-ios-enum'.

07b8905d4e492e012e520658de1257b96b1ea3cf (2015-07-17 11:43:49 -0700)
add TitleCase to enum names to support iOS enum conventions

R=@nicks
R=@jyhsu

Test plan: 'manual'