### PR TITLE
Correct spelling when initializing the 'recursing' property.

### DIFF
--- a/lib/descriptors/ProtoDescriptor.js
+++ b/lib/descriptors/ProtoDescriptor.js
@@ -25,7 +25,7 @@ function ProtoDescriptor(filePath) {
   this._enums = {}
   this._extends = {}
 
-  this._rescursing = false
+  this._recursing = false
 }
 util.inherits(ProtoDescriptor, Descriptor)
 module.exports = ProtoDescriptor


### PR DESCRIPTION
Hello @nicks, 

Please review the following commits I made in branch 'koop-spelling'.

83e4d72e12de9fbe42c68382ca08e60e276bb148 (2015-12-02 10:51:35 -0800)
Correct spelling when initializing the 'recursing' property.

R=@nicks