### PR TITLE
Change pbnj output to be relative to outDir, rather than directly in outDir

### DIFF
--- a/lib/Project.js
+++ b/lib/Project.js
@@ -385,14 +385,15 @@ Project.prototype.compile = function () {
     for (var i = 0; i < this._compileJobs.length; i++) {
       var job = this._compileJobs[i]
       var descriptor = this.getProtos(job.proto)[0]
-      var baseFileName = descriptor.getName()
+      var filePath = descriptor.getFilePath()
       if (job.suffix == '.java' && descriptor.getOption('java_outer_classname')) {
-        baseFileName = descriptor.getOption('java_outer_classname')
+        filePath = path.join(path.dirname(filePath), descriptor.getOption('java_outer_classname'))
       } else if ((job.suffix == '.h' || job.suffix == '.m') && descriptor.getOption('ios_classname')) {
-        baseFileName = descriptor.getOption('ios_classname')
+        filePath = path.join(path.dirname(filePath), descriptor.getOption('ios_classname'))
       }
       var outDir = (job.suffix && this._outDirs[job.suffix]) ? this._outDirs[job.suffix] : this._outDir
-      var fileName = path.join(outDir, baseFileName + (job.suffix || this._defaultSuffix))
+      var relativeFilePath = path.relative(this._basePath, filePath)
+      var fileName = path.join(outDir, relativeFilePath + (job.suffix || this._defaultSuffix))
       var contents =  compiler.render(job.template, descriptor.toTemplateObject())
       promises.push(this._outputFn(descriptor, fileName, contents))
     }

--- a/lib/descriptors/ProtoDescriptor.js
+++ b/lib/descriptors/ProtoDescriptor.js
@@ -76,6 +76,12 @@ ProtoDescriptor.prototype.getName = function () {
 }
 
 
+/** @return {string} */
+ProtoDescriptor.prototype.getFilePath = function () {
+  return this._filePath
+}
+
+
 ProtoDescriptor.prototype.setPackage = function (package) {
   this._package = package
   return this

--- a/tests/project_test.js
+++ b/tests/project_test.js
@@ -61,7 +61,7 @@ builder.add(function testBasicCompilation(test) {
 
       test.equals('Proto=vehicle.proto,Msg=Vehicle,', compilations[0].contents)
 
-      test.equals(path.join(__dirname, 'generated-stuff', 'vehicle.proto.xx.js'), compilations[0].fileName)
+      test.equals(path.join(__dirname, 'generated-stuff/protos', 'vehicle.proto.xx.js'), compilations[0].fileName)
     })
 })
 
@@ -87,14 +87,14 @@ builder.add(function testSuffixSpecificOutputDir(test) {
       test.equals('Proto=vehicle.proto,Msg=Vehicle,', compilations[0].contents)
       test.equals('Proto=vehicle.proto,Msg=Vehicle,', compilations[1].contents)
 
-      test.equals(path.join(__dirname, 'java/generated-stuff', 'VehicleProtos.java'), compilations[0].fileName)
-      test.equals(path.join(__dirname, 'generated-stuff', 'vehicle.proto.xx.js'), compilations[1].fileName)
+      test.equals(path.join(__dirname, 'java/generated-stuff/protos', 'VehicleProtos.java'), compilations[0].fileName)
+      test.equals(path.join(__dirname, 'generated-stuff/protos', 'vehicle.proto.xx.js'), compilations[1].fileName)
     })
 })
 
 
 builder.add(function testDefaultOutputFnWritesFile(test) {
-  var expectedFile = path.join(__dirname, 'generated-stuff2', 'common.proto.js')
+  var expectedFile = path.join(__dirname, 'generated-stuff2/protos', 'common.proto.js')
 
   // Make sure the expected file doesn't exist yet.
   if (fs.existsSync(expectedFile)) fs.unlinkSync(expectedFile)


### PR DESCRIPTION
Hello @dmccartney, 

Please review the following commits I made in branch 'nicks/recursive'.

368cfd9637cb0332a42ae1c9d2376ccd44bbe496 (2016-07-07 11:37:04 -0400)
Change pbnj output to be relative to outDir, rather than directly in outDir
This means that if you compile proto/foo.proto, the output will end
up in out/proto/foo.proto instead of out/foo.proto.

This is more consistent with how the real protoc works and will make it
easier to handle multi-level directory structures.

R=@dmccartney