### PR TITLE
add field level options defined as messages

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -348,9 +348,9 @@ module.exports = function parser(identifier, string) {
       }
 
       if (peek().type == Token.Type.DOT) {
-        expect(Token.Type.DOT)
-        token = expect(Token.Type.WORD)
-        name = token.content
+        var dot = expect(Token.Type.DOT)
+        var sub_field = expect(Token.Type.WORD)
+        name += dot.content + sub_field.content
       }
 
       expect(Token.Type.OPERATOR)

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -331,7 +331,7 @@ module.exports = function parser(identifier, string) {
     })
   }
 
-  // Parses field options: [ name1 = value1, name2 = value2, (name3) = value3 ]
+  // Parses field options: [ name1 = value1, name2 = value2, (name3) = value3, (lib.option_type).name4 = value4 ]
   function parseFieldOptions(parent) {
     parseBlock(function (token) {
       var hasParens = false
@@ -345,6 +345,12 @@ module.exports = function parser(identifier, string) {
       var name = token.content
       if (hasParens) {
         expect(Token.Type.END_PAREN)
+      }
+
+      if (peek().type == Token.Type.DOT) {
+        expect(Token.Type.DOT)
+        token = expect(Token.Type.WORD)
+        name = token.content
       }
 
       expect(Token.Type.OPERATOR)

--- a/lib/tokenize.js
+++ b/lib/tokenize.js
@@ -40,6 +40,7 @@ module.exports = function tokenize(string, fileName) {
     else if (lookingAt(']')) consumeChar(Token.Type.END_OPTION)
     else if (lookingAt('(')) consumeChar(Token.Type.START_PAREN)
     else if (lookingAt(')')) consumeChar(Token.Type.END_PAREN)
+    else if (lookingAt('.')) consumeChar(Token.Type.DOT)
     else if (lookingAtNumberFirstCharacter()) consumeNumber()
     else if (lookingAtWordFirstCharacter()) consumeWord()
     else if (lookingAtRe(/\s/)) nextChar()

--- a/tests/parsing_test.js
+++ b/tests/parsing_test.js
@@ -56,7 +56,7 @@ exports.testKitchenSinkParsing = function (test) {
   test.equal(msg.getField('color_field').getBaseType(), 'Color')
   test.equal(-1, msg.getField('negative_field').getOption('default'))
   test.equal('string', msg.getField('string_field').getOption('default'))
-  test.equal(msg.getField('other_field_option').getOption('name'), 'special')
+  test.equal(msg.getField('other_field_option').getOption('other.field.field_name'), 'special')
 
   test.equal(msg.getOneof('oneof_name').getOneofIndex(), 0)
   test.ok(msg.getField('oneof_field_normal').isOptional())

--- a/tests/parsing_test.js
+++ b/tests/parsing_test.js
@@ -20,7 +20,7 @@ exports.testKitchenSinkParsing = function (test) {
   test.equal(proto.getPackage(), 'some_package')
 
   // Test imports.
-  test.equal(proto.getImportNames().length, 3)
+  test.equal(proto.getImportNames().length, 4)
   test.equal(proto.getImportNames()[0], 'protos/options.proto')
 
   // Test proto level options.
@@ -40,7 +40,7 @@ exports.testKitchenSinkParsing = function (test) {
 
   // Test fields.
   var msg = proto.getMessage('ThisIsTheKitchenSink')
-  test.equal(msg.getFields().length, 12)
+  test.equal(msg.getFields().length, 13)
   test.ok(msg.getField('optional_field').isOptional())
   test.ok(!msg.getField('required_field').isOptional())
   test.ok(!msg.getField('required_field').isRepeated())
@@ -56,6 +56,7 @@ exports.testKitchenSinkParsing = function (test) {
   test.equal(msg.getField('color_field').getBaseType(), 'Color')
   test.equal(-1, msg.getField('negative_field').getOption('default'))
   test.equal('string', msg.getField('string_field').getOption('default'))
+  test.equal(msg.getField('other_field_option').getOption('name'), 'special')
 
   test.equal(msg.getOneof('oneof_name').getOneofIndex(), 0)
   test.ok(msg.getField('oneof_field_normal').isOptional())

--- a/tests/project_test.js
+++ b/tests/project_test.js
@@ -114,7 +114,7 @@ builder.add(function testKitchenSinkProto(test) {
       .addProto('protos/kitchen-sink.proto')
 
   var allProtos = project.getProtos().map(getProtoName)
-  test.deepEqual(['kitchen-sink.proto', 'options.proto', 'descriptor.proto', 'common.proto'], allProtos)
+  test.deepEqual(['kitchen-sink.proto', 'options.proto', 'descriptor.proto', 'otherOptions.proto', 'common.proto'], allProtos)
 
   return project.setOutDir('generated-stuff3').compile()
 })

--- a/tests/protos/kitchen-sink.proto
+++ b/tests/protos/kitchen-sink.proto
@@ -34,7 +34,7 @@ message ThisIsTheKitchenSink {
 
   optional bool sherlock_lives_at_221b = 12;
   optional bool call_867_5309 = 13;
-  optional string other_field_option = 14 [(other.field).name="special"];
+  optional string other_field_option = 14 [(other.field).field_name='special'];
 }
 
 

--- a/tests/protos/kitchen-sink.proto
+++ b/tests/protos/kitchen-sink.proto
@@ -7,6 +7,7 @@
 package some_package;
 
 import "protos/options.proto";
+import "protos/otherOptions.proto";
 import "protos/common.proto";
 import "google/protobuf/descriptor.proto";
 
@@ -33,6 +34,7 @@ message ThisIsTheKitchenSink {
 
   optional bool sherlock_lives_at_221b = 12;
   optional bool call_867_5309 = 13;
+  optional string other_field_option = 14 [(other.field).name="special"];
 }
 
 

--- a/tests/protos/otherOptions.proto
+++ b/tests/protos/otherOptions.proto
@@ -3,7 +3,7 @@ package other;
 import "google/protobuf/descriptor.proto";
 
 message FieldOptions {
-  optional string name = 1;
+  optional string field_name = 1;
 }
 
 extend google.protobuf.FieldOptions {

--- a/tests/protos/otherOptions.proto
+++ b/tests/protos/otherOptions.proto
@@ -1,0 +1,11 @@
+package other;
+
+import "google/protobuf/descriptor.proto";
+
+message FieldOptions {
+  optional string name = 1;
+}
+
+extend google.protobuf.FieldOptions {
+  optional FieldOptions field = 1020;
+}


### PR DESCRIPTION
Hello @dmccartney, @dangilk, 

pbnj currently is unable to parse field options that are defined as Messages in another protobuf.
i.e. 
```proto
import "options.proto";

...

optional string name = 1 [(options.field).other_name = "otherName"];
```
where `options.proto` defines a field level option as:
```proto
import google/protobuf/descriptor.proto

...

message FieldOptions {
  optional string other_name = 1;
}

extend google.protobuf.FieldOptions {
  optional FieldOptions field = 1020;
}
```

Please review the following commits I made in branch 'sachee/parse_options_defined_in_message'.

b5ba4d1fd3a3ffcc75dd1a5218f8e0dc49890cec (2017-03-01 13:41:40 -0800)
add field level options defined as messages

R=@dmcartney
R=@dangilk

MANUAL TESTING=added tests

Code review reminders. By giving a LGTM you attest that: 
- Commits are adequately tested 
- Code is easy to understand and conforms to our [style guides](https://github.com/Medium/docs/tree/master/style-guide) 
- Incomplete code is marked with TODOs 
- Logging and metrics are suitable 