### PR TITLE
add parsing for syntax (used in scalapb)

### DIFF
--- a/lib/descriptors/ProtoDescriptor.js
+++ b/lib/descriptors/ProtoDescriptor.js
@@ -58,6 +58,7 @@ ProtoDescriptor.prototype.toTemplateObject = function () {
   var result = {
     name: this.getName(),
     package: this._package,
+    syntax: this._syntax,
     options: this._options,
     importNames: this._importNames,
     get messages() {
@@ -104,6 +105,16 @@ ProtoDescriptor.prototype.setPackage = function (package) {
 
 ProtoDescriptor.prototype.getPackage = function () {
   return this._package
+}
+
+ProtoDescriptor.prototype.setSyntax = function (syntax) {
+  this._syntax = syntax
+  return this
+}
+
+
+ProtoDescriptor.prototype.getSyntax = function () {
+  return this._syntax
 }
 
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -50,6 +50,9 @@ module.exports = function parser(identifier, string) {
       case 'package':
         parsePackage()
         break
+      case 'syntax':
+        parseSyntax()
+        break
       case 'option':
         parseOption(proto)
         break
@@ -79,6 +82,14 @@ module.exports = function parser(identifier, string) {
   function parsePackage() {
     proto.setPackage(expect(Token.Type.WORD).content)
     expect(Token.Type.TERMINATOR)
+  }
+
+  // Parses the syntax statement: syntax = "proto2";
+  function parseSyntax() {
+    expect(Token.Type.OPERATOR)
+    var syntax = expect(Token.Type.STRING).content
+    expect(Token.Type.TERMINATOR)
+    proto.setSyntax(syntax)
   }
 
   // Parses a file level option:

--- a/tests/parsing_test.js
+++ b/tests/parsing_test.js
@@ -19,6 +19,8 @@ exports.testKitchenSinkParsing = function (test) {
 
   test.equal(proto.getPackage(), 'some_package')
 
+  test.equal(proto.getSyntax(), 'proto2')
+
   // Test imports.
   test.equal(proto.getImportNames().length, 4)
   test.equal(proto.getImportNames()[0], 'protos/options.proto')

--- a/tests/protos/kitchen-sink.proto
+++ b/tests/protos/kitchen-sink.proto
@@ -4,6 +4,8 @@
  * Both comment types should be supported and ignore other tokens such as message FooBar { }.
  */
 
+syntax = "proto2";
+
 package some_package;
 
 import "protos/options.proto";


### PR DESCRIPTION
Hello @dangilk, @dmccartney, 
Here I am again...

It looks like there is also a fancy `syntax` field that can be added to protos and is used in ScalaPB.
e.g. `syntax = "proto2";`

So I'm adding the ability to parse `syntax` in protos.

Please review the following commits I made in branch 'sachee/parse_syntax'.

abacb0eb7761e8810fbd8a2f49ef8c7de8de6e86 (2017-03-15 16:52:07 -0700)
add parsing for syntax (used in scalapb)

R=@dangilk
R=@dmccartney