### PR TITLE
add ability to parse block options (used in scalapb)

### DIFF
--- a/lib/Token.js
+++ b/lib/Token.js
@@ -39,7 +39,8 @@ Token.Type = {
   END_OPTION: 11,
   NUMBER: 12,
   START_PAREN: 13,
-  END_PAREN: 14
+  END_PAREN: 14,
+  COLON: 15
 }
 
 
@@ -64,6 +65,7 @@ Token.toErrorString = function (value) {
     case Token.Type.START_PAREN: return '( (open parenthesis)'
     case Token.Type.END_PAREN: return ') (close parenthesis)'
     case Token.Type.NUMBER: return 'number'
+    case Token.Type.COLON: return ': (begin definition)'
     default:
       return 'Token Value=' + value
   }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -420,7 +420,7 @@ module.exports = function parser(identifier, string) {
       }
     }
   }
-  
+
   function isComment(token) {
     return isInArray(token, [Token.Type.LINE_COMMENT, Token.Type.BLOCK_COMMENT])
   }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -95,6 +95,10 @@ module.exports = function parser(identifier, string) {
   // Parses a file level option:
   // option optionName = "optionValue";
   // option (optionName) = "optionValue";
+  // option (optionName) = {
+  //   package_name: "some.options"
+  //   flat_package: true
+  // };
   function parseOption(parent) {
     var hasParens = false
     if (peek().type == Token.Type.START_PAREN) {
@@ -108,10 +112,26 @@ module.exports = function parser(identifier, string) {
     }
 
     expect(Token.Type.OPERATOR) // equals
-    var value = expect([Token.Type.STRING, Token.Type.WORD])
-    expect(Token.Type.TERMINATOR)
-    parent.addOption(key.content, value.content)
-    // TODO : Handle duplicate options.
+
+    // option block
+    if (peek().type == Token.Type.START_BLOCK) {
+      parseBlock(function(token) {
+        var sub_key = token.content
+        var option_key = key.content + '.' + sub_key
+
+        expect(Token.Type.COLON)
+
+        var value = expect([Token.Type.STRING, Token.Type.WORD])
+        parent.addOption(option_key, value.content)
+    })
+    expectOptional(Token.Type.TERMINATOR)
+    
+    // single line option
+    } else {
+      var value = expect([Token.Type.STRING, Token.Type.WORD])
+      expect(Token.Type.TERMINATOR)
+      parent.addOption(key.content, value.content)
+    }
   }
 
   // Parses an import statement: import "filename";
@@ -400,7 +420,7 @@ module.exports = function parser(identifier, string) {
       }
     }
   }
-
+  
   function isComment(token) {
     return isInArray(token, [Token.Type.LINE_COMMENT, Token.Type.BLOCK_COMMENT])
   }

--- a/lib/tokenize.js
+++ b/lib/tokenize.js
@@ -41,6 +41,7 @@ module.exports = function tokenize(string, fileName) {
     else if (lookingAt('(')) consumeChar(Token.Type.START_PAREN)
     else if (lookingAt(')')) consumeChar(Token.Type.END_PAREN)
     else if (lookingAt('.')) consumeChar(Token.Type.DOT)
+    else if (lookingAt(':')) consumeChar(Token.Type.COLON)
     else if (lookingAtNumberFirstCharacter()) consumeNumber()
     else if (lookingAtWordFirstCharacter()) consumeWord()
     else if (lookingAtRe(/\s/)) nextChar()

--- a/tests/parsing_test.js
+++ b/tests/parsing_test.js
@@ -26,9 +26,11 @@ exports.testKitchenSinkParsing = function (test) {
   test.equal(proto.getImportNames()[0], 'protos/options.proto')
 
   // Test proto level options.
-  test.equal(proto.getOptionKeys().length, 2)
+  test.equal(proto.getOptionKeys().length, 4)
   test.equal(proto.getOption('file_level_option'), 'string value')
   test.equal(proto.getOption('another_option'), 'Just "testing" that strings parse.')
+  test.equal(proto.getOption('options.package_name'), 'some.options')
+  test.equal(proto.getOption('options.flat_package'), 'true')
 
   // Test message level options.
   test.equals(proto.getMessage('AnotherMessage').getOption('message_level_option'), 'XYZ')

--- a/tests/protos/kitchen-sink.proto
+++ b/tests/protos/kitchen-sink.proto
@@ -15,7 +15,10 @@ import "google/protobuf/descriptor.proto";
 
 option (file_level_option) = "string value";
 option (another_option) = "Just \"testing\" that strings parse.";
-
+option (options) = {
+  package_name: "some.options"
+  flat_package: true
+};
 
 message ThisIsTheKitchenSink {
   required string required_field = 1;


### PR DESCRIPTION
Hello @dangilk, @silverlyra, 

Please review the following commits I made in branch 'sachee/add-block-option-parsing'.

b26696ce718638fcb8d59b757c3ec1026da6f2fe (2018-07-31 17:43:07 -0700)
added tests for block options

a3ffeba2929ad8a8a2a6656b9c2dacafc80257c7 (2018-07-31 17:43:07 -0700)
add tokens, tokenizing, and parsing for block options

R=@dangilk
R=@silverlyra