### PR TITLE
Ignore reserved lists

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -197,6 +197,9 @@ module.exports = function parser(identifier, string) {
         case 'repeated':
           parseRepeatedField(message)
           break
+        case 'reserved':
+          parseReserved()
+          break
         default:
           if (proto.getSyntax() == 'proto3') {
             tokens.unshift(token)
@@ -425,6 +428,18 @@ module.exports = function parser(identifier, string) {
       parent.addOption(name, value)
       expectOptional(Token.Type.DELIMITER)
     }, Token.Type.START_OPTION, Token.Type.END_OPTION)
+  }
+
+  // Parses a reserved list (and ignore it).
+  function parseReserved() {
+    // Ignore everything until the terminator token.
+    while (true) {
+      var type = peek().type
+      expect(type)
+      if (type == Token.Type.TERMINATOR) {
+        break
+      }
+    }
   }
 
   // Parses a block, calling fn for each token until the end token is seen.

--- a/tests/protos/kitchen-sink-v3.proto
+++ b/tests/protos/kitchen-sink-v3.proto
@@ -34,6 +34,11 @@ message ThisIsTheKitchenSinkV3 {
   bool sherlock_lives_at_221b = 10;
   bool call_867_5309 = 11;
   string other_field_option = 12 [(other.field).field_name='special'];
+
+  reserved 20230619100;
+  reserved 20230619200, 20230619300 to 20230619400;
+  reserved "this_is_reserved";
+  reserved "this_too_is_reserved", "this_also_is_reserved";
 }
 
 message SomeCoolMessage {

--- a/tests/protos/kitchen-sink.proto
+++ b/tests/protos/kitchen-sink.proto
@@ -63,6 +63,11 @@ message ThisIsTheKitchenSink {
   optional bool sherlock_lives_at_221b = 12;
   optional bool call_867_5309 = 13;
   optional string other_field_option = 14 [(other.field).field_name='special'];
+
+  reserved 20230619100;
+  reserved 20230619200, 20230619300 to 20230619400;
+  reserved "this_is_reserved";
+  reserved "this_too_is_reserved", "this_also_is_reserved";
 }
 
 


### PR DESCRIPTION

This instructs the parser to silently ignore reserved lists ([proto2][reserved-proto2], [proto3][reserved-proto3]).

Manual testing: `npm test`

[reserved-proto2]: https://protobuf.dev/programming-guides/proto2/#fieldreserved
[reserved-proto3]: https://protobuf.dev/programming-guides/proto3/#fieldreserved