### PR TITLE
Revert kew dependency to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "mkdirp": "0.3.5",
-    "kew": "git+https://github.com/Medium/kew#b8aaf9f",
+    "kew": "0.7.0",
     "soynode": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION

This reverts commits d4467b41, 88a026e5, 80c3d005, 0c56f6c7, and 52d5523e.